### PR TITLE
Support the admin API for registering push subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailhouse/client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/src/admin.test.ts
+++ b/src/admin.test.ts
@@ -1,0 +1,52 @@
+import { AdminRequests } from "../test/utils.js";
+import { SailhouseClient } from "./index.js";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("Sailhouse Admin Client", () => {
+  let client: SailhouseClient;
+  
+  beforeEach(() => {
+    client = new SailhouseClient("key");
+  });
+
+  it("should register a push subscription", async () => {
+    const result = await client.admin.registerPushSubscription(
+      "topic", 
+      "subscription", 
+      "https://example.com/webhook"
+    );
+
+    expect(result.outcome).toBe("created");
+    expect(AdminRequests).toHaveLength(1);
+    expect(AdminRequests[0].topic).toBe("topic");
+    expect(AdminRequests[0].subscription).toBe("subscription");
+    expect(AdminRequests[0].type).toBe("push");
+    expect(AdminRequests[0].endpoint).toBe("https://example.com/webhook");
+    expect(AdminRequests[0].filter).toBeUndefined();
+  });
+
+  it("should register a push subscription with filter", async () => {
+    const result = await client.admin.registerPushSubscription(
+      "topic", 
+      "subscription", 
+      "https://example.com/webhook",
+      {
+        filter: {
+          path: "data.type",
+          value: "test"
+        }
+      }
+    );
+
+    expect(result.outcome).toBe("created");
+    expect(AdminRequests).toHaveLength(1);
+    expect(AdminRequests[0].topic).toBe("topic");
+    expect(AdminRequests[0].subscription).toBe("subscription");
+    expect(AdminRequests[0].type).toBe("push");
+    expect(AdminRequests[0].endpoint).toBe("https://example.com/webhook");
+    expect(AdminRequests[0].filter).toEqual({
+      path: "data.type",
+      value: "test"
+    });
+  });
+});

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,0 +1,37 @@
+import { Wretch } from "wretch";
+import { QueryStringAddon } from "wretch/addons/queryString";
+
+type RegisterResult = {
+  outcome: "created" | "updated" | "none";
+};
+
+export class AdminClient {
+  private api: QueryStringAddon & Wretch<QueryStringAddon>;
+
+  constructor(api: QueryStringAddon & Wretch<QueryStringAddon>) {
+    this.api = api;
+  }
+
+  registerPushSubscription = async (
+    topic: string,
+    subscription: string,
+    endpoint: string,
+    options?: {
+      filter?: {
+        path: string;
+        value: string;
+      };
+    },
+  ): Promise<RegisterResult> => {
+    const result = await this.api
+      .url(`/api/v1/topics/${topic}/subscriptions/${subscription}`)
+      .put({
+        type: "push",
+        endpoint,
+        filter: options?.filter,
+      })
+      .json<RegisterResult>();
+
+    return result;
+  };
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,4 +35,18 @@ describe("Sailhouse Client", () => {
     expect(EventRequests).toHaveLength(1);
     expect(EventRequests[0].send_at).toBe(date.toISOString());
   });
+
+  it("should pull a subscription event", async () => {
+    const event = await client.pull("topic", "subscription");
+
+    expect(event).not.toBeNull();
+    expect(event?.id).toBe("1");
+    expect(event?.data).toEqual({ foo: "bar" });
+  });
+
+  it("should return null if no events are available", async () => {
+    const event = await client.pull("topic", "empty");
+
+    expect(event).toBeNull();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import { AdminClient } from "./admin.js";
 import { Wretch, default as w } from "wretch";
 import { default as addon, QueryStringAddon } from "wretch/addons/queryString";
-import WebSocket from "ws";
 
 // Nested keyof utility type
 type NestedKeyOf<T, U = T> = U extends object
@@ -83,6 +83,7 @@ type PublishEventOptions = {
 export class SailhouseClient {
   private api: QueryStringAddon & Wretch<QueryStringAddon>;
   private apiKey: string;
+  public admin: AdminClient;
 
   constructor(apiKey: string, opts?: Partial<Options>) {
     this.api = w()
@@ -95,6 +96,7 @@ export class SailhouseClient {
       .url("https://api.sailhouse.dev");
 
     this.apiKey = apiKey;
+    this.admin = new AdminClient(this.api);
   }
 
   getEvents = async <T extends unknown>(

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -52,6 +52,24 @@ const server = setupServer(
       return res(ctx.json({}));
     },
   ),
+  rest.get(
+    "https://api.sailhouse.dev/topics/:topic/subscriptions/:subscription/events/pull",
+    async (req, res, ctx) => {
+      if (req.params.subscription === "empty") {
+        return res(ctx.status(204));
+      }
+
+      return res(
+        ctx.json({
+          id: "1",
+          data: {
+            foo: "bar",
+          },
+          created_at: "2021-01-01T00:00:00Z",
+        }),
+      );
+    },
+  ),
 );
 
 beforeEach(() => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,6 +3,7 @@ import { setupServer } from "msw/node";
 import { afterAll, beforeAll, beforeEach } from "vitest";
 
 export const EventRequests: any[] = [];
+export const AdminRequests: any[] = [];
 
 const server = setupServer(
   rest.get(
@@ -70,10 +71,28 @@ const server = setupServer(
       );
     },
   ),
+  rest.put(
+    "https://api.sailhouse.dev/api/v1/topics/:topic/subscriptions/:subscription",
+    async (req, res, ctx) => {
+      const body = await req.json();
+      AdminRequests.push({
+        ...body,
+        topic: req.params.topic,
+        subscription: req.params.subscription,
+      });
+
+      return res(
+        ctx.json({
+          outcome: "created",
+        }),
+      );
+    },
+  ),
 );
 
 beforeEach(() => {
   EventRequests.length = 0;
+  AdminRequests.length = 0;
 });
 
 beforeAll(() => {


### PR DESCRIPTION
We have an admin API to allow push subscriptions to be registered from the client, this will allow deployments to platforms such as Netlify to automatically register the push subscriptions as part of a build process.

```ts
// This is a Netlify build time environment variable referencing the URL the
// site will be available at
//
// Reference: https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
const BASE = process.env.DEPLOY_PRIME_URL;

await sailhouse.admin.registerPushSubscription(
  "github-webhook",
  "pull-request-created",
  `${BASE}/api/pull-request-created`,
  {
     filter: {
        path: "event_type",
        event: "pull_request",
    },
  }
);

await sailhouse.admin.registerPushSubscription(
  "pr-analysed",
  "add-comment",
  `${BASE}/api/add-pr-comment`
);
```
