### PR TITLE
Add pattern for long-running subscribers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailhouse/client",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",


### PR DESCRIPTION
This introduces a pattern for long-running subscribers with the SDK, intending to introduce a simple way to spin up worker processes which can just be left.

```ts
import { SailhouseClient } from "@sailhouse/client";

const client = new SailhouseClient(process.env.SAILHOUSE_API_KEY);

const subscriber = client.subscriber({
  // This allows us to have 3 workers in parallel working on each subscriber
  //
  // This defaults to 1 under the hood, but gives us a huge amount of processing power to
  // parrelise consumption of events!
  perSubscriptionProcessors: 3,
});

subscriber.subscribe(
  "my-topic",
  "my-subscription",
  // Event is automatically acknowledged if an error is not thrown
  async ({ event }) => {
    console.log(`Receieved event: ${event.id}`);
  },
);

await subscriber.start();
```