### PR TITLE
Support HMAC push subscription verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ The [Sailhouse](https://sailhouse.dev) Client provides an idomatic abstraction o
 const token = "sh_" // ......
 const client = new SailhouseClient(token);
 
-await client.sendEvent("test-event", { message: "Hello World!" });
+await client.publish("test-event", { message: "Hello World!" });
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "test": "vitest",
+    "test:ci": "vitest run",
     "build": "tsc --project tsconfig.build.json"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailhouse/client",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,22 @@
 import { AdminClient } from "./admin.js";
+import {
+  PushSubscriptionVerifier,
+  VerificationOptions,
+} from "./pushSubscriptions.js";
 import { Wretch, default as w } from "wretch";
 import { default as addon, QueryStringAddon } from "wretch/addons/queryString";
+
+// Export push subscription types and functions
+export {
+  PushSubscriptionVerifier,
+  PushSubscriptionVerificationError,
+  verifyPushSubscriptionSignature,
+  verifyPushSubscriptionSignatureSafe,
+  type SignatureComponents,
+  type PushSubscriptionHeaders,
+  type PushSubscriptionPayload,
+  type VerificationOptions,
+} from "./pushSubscriptions.js";
 
 // Nested keyof utility type
 type NestedKeyOf<T, U = T> = U extends object
@@ -210,5 +226,35 @@ export class SailhouseClient {
       .url(`/waitgroups/instances/${wait_group_instance_id}/events`)
       .put({})
       .res();
+  };
+
+  /**
+   * Verify a push subscription signature
+   * @param signature The Sailhouse-Signature header value
+   * @param body The raw request body as string
+   * @param secret The push subscription secret
+   * @param options Verification options
+   * @returns true if signature is valid
+   * @throws PushSubscriptionVerificationError if verification fails
+   */
+  verifyPushSubscription = (
+    signature: string,
+    body: string,
+    secret: string,
+    options?: VerificationOptions,
+  ): boolean => {
+    const verifier = new PushSubscriptionVerifier(secret);
+    return verifier.verifySignature(signature, body, options);
+  };
+
+  /**
+   * Create a push subscription verifier instance
+   * @param secret The push subscription secret
+   * @returns PushSubscriptionVerifier instance
+   */
+  createPushSubscriptionVerifier = (
+    secret: string,
+  ): PushSubscriptionVerifier => {
+    return new PushSubscriptionVerifier(secret);
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { AdminClient } from "./admin.js";
 import {
   PushSubscriptionVerifier,
   VerificationOptions,
-} from "./pushSubscriptions.js";
+} from "./push-subscriptions.js";
 import { Wretch, default as w } from "wretch";
 import { default as addon, QueryStringAddon } from "wretch/addons/queryString";
 
@@ -16,7 +16,7 @@ export {
   type PushSubscriptionHeaders,
   type PushSubscriptionPayload,
   type VerificationOptions,
-} from "./pushSubscriptions.js";
+} from "./push-subscriptions.js";
 
 // Nested keyof utility type
 type NestedKeyOf<T, U = T> = U extends object

--- a/src/push-subscriptions.test.ts
+++ b/src/push-subscriptions.test.ts
@@ -1,0 +1,476 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "crypto";
+import {
+  PushSubscriptionVerifier,
+  PushSubscriptionVerificationError,
+  verifyPushSubscriptionSignature,
+  verifyPushSubscriptionSignatureSafe,
+} from "./push-subscriptions.js";
+
+describe("PushSubscriptionVerifier", () => {
+  const secret = "test-secret-key";
+  const verifier = new PushSubscriptionVerifier(secret);
+
+  describe("constructor", () => {
+    it("should create verifier with secret", () => {
+      expect(() => new PushSubscriptionVerifier(secret)).not.toThrow();
+    });
+
+    it("should throw error for empty secret", () => {
+      expect(() => new PushSubscriptionVerifier("")).toThrow(
+        "Push subscription secret is required",
+      );
+    });
+
+    it("should throw error for null secret", () => {
+      expect(() => new PushSubscriptionVerifier(null as any)).toThrow(
+        "Push subscription secret is required",
+      );
+    });
+  });
+
+  describe("parseSignatureHeader", () => {
+    it("should parse valid signature header", () => {
+      const header = "t=1699564800,v1=abc123";
+      const result = verifier.parseSignatureHeader(header);
+
+      expect(result.timestamp).toBe(1699564800);
+      expect(result.signature).toBe("abc123");
+    });
+
+    it("should parse header with spaces", () => {
+      const header = "t=1699564800, v1=abc123";
+      const result = verifier.parseSignatureHeader(header);
+
+      expect(result.timestamp).toBe(1699564800);
+      expect(result.signature).toBe("abc123");
+    });
+
+    it("should parse header with extra elements", () => {
+      const header = "t=1699564800,v1=abc123,extra=value";
+      const result = verifier.parseSignatureHeader(header);
+
+      expect(result.timestamp).toBe(1699564800);
+      expect(result.signature).toBe("abc123");
+    });
+
+    it("should throw error for missing header", () => {
+      expect(() => verifier.parseSignatureHeader("")).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.parseSignatureHeader("")).toThrow(
+        "Signature header is required",
+      );
+    });
+
+    it("should throw error for missing timestamp", () => {
+      const header = "v1=abc123";
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        "Invalid signature header format",
+      );
+    });
+
+    it("should throw error for missing signature", () => {
+      const header = "t=1699564800";
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        "Invalid signature header format",
+      );
+    });
+
+    it("should throw error for invalid timestamp", () => {
+      const header = "t=invalid,v1=abc123";
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        "Invalid timestamp in signature header",
+      );
+    });
+
+    it("should throw error for malformed header", () => {
+      const header = "invalid-format";
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.parseSignatureHeader(header)).toThrow(
+        "Invalid signature header format",
+      );
+    });
+  });
+
+  describe("isTimestampValid", () => {
+    it("should return true for current timestamp", () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      expect(verifier.isTimestampValid(currentTime, 300)).toBe(true);
+    });
+
+    it("should return true for timestamp within tolerance", () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const timestamp = currentTime - 100; // 100 seconds ago
+      expect(verifier.isTimestampValid(timestamp, 300)).toBe(true);
+    });
+
+    it("should return false for timestamp outside tolerance", () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const timestamp = currentTime - 400; // 400 seconds ago
+      expect(verifier.isTimestampValid(timestamp, 300)).toBe(false);
+    });
+
+    it("should return false for future timestamp", () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const timestamp = currentTime + 100; // 100 seconds in future
+      expect(verifier.isTimestampValid(timestamp, 300)).toBe(false);
+    });
+
+    it("should handle zero tolerance", () => {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const timestamp = currentTime - 1; // 1 second ago
+      expect(verifier.isTimestampValid(timestamp, 0)).toBe(false);
+    });
+  });
+
+  describe("calculateSignature", () => {
+    it("should calculate correct HMAC-SHA256 signature", () => {
+      const timestamp = 1699564800;
+      const body = '{"test": "data"}';
+      const payload = `${timestamp}.${body}`;
+
+      const expectedSignature = createHmac("sha256", secret)
+        .update(payload)
+        .digest("hex");
+
+      const result = verifier.calculateSignature(timestamp, body);
+      expect(result).toBe(expectedSignature);
+    });
+
+    it("should produce different signatures for different bodies", () => {
+      const timestamp = 1699564800;
+      const body1 = '{"test": "data1"}';
+      const body2 = '{"test": "data2"}';
+
+      const sig1 = verifier.calculateSignature(timestamp, body1);
+      const sig2 = verifier.calculateSignature(timestamp, body2);
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it("should produce different signatures for different timestamps", () => {
+      const body = '{"test": "data"}';
+      const timestamp1 = 1699564800;
+      const timestamp2 = 1699564801;
+
+      const sig1 = verifier.calculateSignature(timestamp1, body);
+      const sig2 = verifier.calculateSignature(timestamp2, body);
+
+      expect(sig1).not.toBe(sig2);
+    });
+  });
+
+  describe("verifySignature", () => {
+    // Helper function to create a valid signature
+    const createValidSignature = (timestamp: number, body: string): string => {
+      const payload = `${timestamp}.${body}`;
+      const signature = createHmac("sha256", secret)
+        .update(payload)
+        .digest("hex");
+      return `t=${timestamp},v1=${signature}`;
+    };
+
+    it("should verify valid signature", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const body = '{"event": "test", "data": {"message": "hello"}}';
+      const signature = createValidSignature(timestamp, body);
+
+      expect(verifier.verifySignature(signature, body)).toBe(true);
+    });
+
+    it("should verify signature with custom tolerance", () => {
+      const timestamp = Math.floor(Date.now() / 1000) - 500; // 500 seconds ago
+      const body = '{"event": "test"}';
+      const signature = createValidSignature(timestamp, body);
+
+      expect(
+        verifier.verifySignature(signature, body, { tolerance: 600 }),
+      ).toBe(true);
+    });
+
+    it("should throw error for invalid signature", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const body = '{"event": "test"}';
+      const signature = `t=${timestamp},v1=invalidsignature`;
+
+      expect(() => verifier.verifySignature(signature, body)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.verifySignature(signature, body)).toThrow(
+        "Signature verification failed",
+      );
+    });
+
+    it("should throw error for expired timestamp", () => {
+      const timestamp = Math.floor(Date.now() / 1000) - 400; // 400 seconds ago
+      const body = '{"event": "test"}';
+      const signature = createValidSignature(timestamp, body);
+
+      expect(() => verifier.verifySignature(signature, body)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+      expect(() => verifier.verifySignature(signature, body)).toThrow(
+        "Request timestamp is too old",
+      );
+    });
+
+    it("should throw error for malformed signature header", () => {
+      const body = '{"event": "test"}';
+      const signature = "invalid-header";
+
+      expect(() => verifier.verifySignature(signature, body)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+    });
+
+    it("should handle empty body", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const body = "";
+      const signature = createValidSignature(timestamp, body);
+
+      expect(verifier.verifySignature(signature, body)).toBe(true);
+    });
+
+    it("should handle complex JSON body", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const body = JSON.stringify({
+        id: "event-123",
+        data: {
+          user: { name: "John Doe", email: "john@example.com" },
+          action: "purchase",
+          items: [
+            { id: 1, name: "Product A" },
+            { id: 2, name: "Product B" },
+          ],
+        },
+        metadata: { source: "api", version: "1.0" },
+      });
+      const signature = createValidSignature(timestamp, body);
+
+      expect(verifier.verifySignature(signature, body)).toBe(true);
+    });
+
+    it("should be sensitive to body changes", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const originalBody = '{"event": "test", "data": {"message": "hello"}}';
+      const modifiedBody = '{"event": "test", "data": {"message": "hello!"}}';
+      const signature = createValidSignature(timestamp, originalBody);
+
+      // Should pass with original body
+      expect(verifier.verifySignature(signature, originalBody)).toBe(true);
+
+      // Should fail with modified body
+      expect(() => verifier.verifySignature(signature, modifiedBody)).toThrow(
+        PushSubscriptionVerificationError,
+      );
+    });
+
+    it("should handle unicode characters in body", () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const body = '{"message": "Hello 🌍 World! 你好"}';
+      const signature = createValidSignature(timestamp, body);
+
+      expect(verifier.verifySignature(signature, body)).toBe(true);
+    });
+  });
+});
+
+describe("verifyPushSubscriptionSignature", () => {
+  const secret = "test-secret-key";
+
+  const createValidSignature = (timestamp: number, body: string): string => {
+    const payload = `${timestamp}.${body}`;
+    const signature = createHmac("sha256", secret)
+      .update(payload)
+      .digest("hex");
+    return `t=${timestamp},v1=${signature}`;
+  };
+
+  it("should verify valid signature", () => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body = '{"event": "test"}';
+    const signature = createValidSignature(timestamp, body);
+
+    expect(verifyPushSubscriptionSignature(secret, signature, body)).toBe(true);
+  });
+
+  it("should throw error for invalid signature", () => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body = '{"event": "test"}';
+    const signature = `t=${timestamp},v1=invalidsignature`;
+
+    expect(() =>
+      verifyPushSubscriptionSignature(secret, signature, body),
+    ).toThrow(PushSubscriptionVerificationError);
+  });
+
+  it("should respect custom tolerance", () => {
+    const timestamp = Math.floor(Date.now() / 1000) - 500; // 500 seconds ago
+    const body = '{"event": "test"}';
+    const signature = createValidSignature(timestamp, body);
+
+    expect(
+      verifyPushSubscriptionSignature(secret, signature, body, {
+        tolerance: 600,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("verifyPushSubscriptionSignatureSafe", () => {
+  const secret = "test-secret-key";
+
+  const createValidSignature = (timestamp: number, body: string): string => {
+    const payload = `${timestamp}.${body}`;
+    const signature = createHmac("sha256", secret)
+      .update(payload)
+      .digest("hex");
+    return `t=${timestamp},v1=${signature}`;
+  };
+
+  it("should return true for valid signature", () => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body = '{"event": "test"}';
+    const signature = createValidSignature(timestamp, body);
+
+    expect(verifyPushSubscriptionSignatureSafe(secret, signature, body)).toBe(
+      true,
+    );
+  });
+
+  it("should return false for invalid signature instead of throwing", () => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body = '{"event": "test"}';
+    const signature = `t=${timestamp},v1=invalidsignature`;
+
+    expect(verifyPushSubscriptionSignatureSafe(secret, signature, body)).toBe(
+      false,
+    );
+  });
+
+  it("should return false for expired timestamp instead of throwing", () => {
+    const timestamp = Math.floor(Date.now() / 1000) - 400; // 400 seconds ago
+    const body = '{"event": "test"}';
+    const signature = createValidSignature(timestamp, body);
+
+    expect(verifyPushSubscriptionSignatureSafe(secret, signature, body)).toBe(
+      false,
+    );
+  });
+
+  it("should return false for malformed signature instead of throwing", () => {
+    const body = '{"event": "test"}';
+    const signature = "invalid-header";
+
+    expect(verifyPushSubscriptionSignatureSafe(secret, signature, body)).toBe(
+      false,
+    );
+  });
+});
+
+describe("PushSubscriptionVerificationError", () => {
+  it("should create error with message and code", () => {
+    const error = new PushSubscriptionVerificationError(
+      "Test message",
+      "TEST_CODE",
+    );
+
+    expect(error.message).toBe("Test message");
+    expect(error.code).toBe("TEST_CODE");
+    expect(error.name).toBe("PushSubscriptionVerificationError");
+  });
+
+  it("should be instanceof Error", () => {
+    const error = new PushSubscriptionVerificationError(
+      "Test message",
+      "TEST_CODE",
+    );
+
+    expect(error instanceof Error).toBe(true);
+    expect(error instanceof PushSubscriptionVerificationError).toBe(true);
+  });
+});
+
+describe("Real-world examples", () => {
+  const secret = "whsec_test_secret";
+
+  it("should handle example from documentation", () => {
+    // This mirrors the example signature format from the docs
+    const timestamp = Math.floor(Date.now() / 1000) - 100; // 100 seconds ago
+    const body =
+      '{"id":"evt_123","data":{"user":"john@example.com","action":"signup"},"timestamp":"2023-11-09T16:00:00Z"}';
+
+    // Create signature manually to match docs format
+    const payload = `${timestamp}.${body}`;
+    const signature = createHmac("sha256", secret)
+      .update(payload)
+      .digest("hex");
+    const header = `t=${timestamp},v1=${signature}`;
+
+    const verifier = new PushSubscriptionVerifier(secret);
+
+    // Should pass with default tolerance
+    expect(verifier.verifySignature(header, body)).toBe(true);
+  });
+
+  it("should handle Express.js raw body scenario", () => {
+    // Simulate Express with express.raw({ type: 'application/json' })
+    const timestamp = Math.floor(Date.now() / 1000);
+    const jsonData = {
+      event: "user.created",
+      data: { id: 123, email: "user@example.com" },
+    };
+    const body = JSON.stringify(jsonData);
+
+    // Simulate raw body as Buffer (common in Express)
+    const bodyBuffer = Buffer.from(body, "utf8");
+    const bodyString = bodyBuffer.toString("utf8");
+
+    const payload = `${timestamp}.${bodyString}`;
+    const signature = createHmac("sha256", secret)
+      .update(payload)
+      .digest("hex");
+    const header = `t=${timestamp},v1=${signature}`;
+
+    const verifier = new PushSubscriptionVerifier(secret);
+    expect(verifier.verifySignature(header, bodyString)).toBe(true);
+  });
+
+  it("should handle different content types", () => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const verifier = new PushSubscriptionVerifier(secret);
+
+    // Test with different JSON structures
+    const testCases = [
+      '{"simple": "object"}',
+      '{"nested": {"deep": {"value": 123}}}',
+      '{"array": [1, 2, 3, "string", {"nested": true}]}',
+      '{"unicode": "测试 🚀 émoji"}',
+      '{"number": 123.456, "boolean": true, "null": null}',
+      "[]", // Empty array
+      "{}", // Empty object
+    ];
+
+    testCases.forEach((body) => {
+      const payload = `${timestamp}.${body}`;
+      const signature = createHmac("sha256", secret)
+        .update(payload)
+        .digest("hex");
+      const header = `t=${timestamp},v1=${signature}`;
+
+      expect(verifier.verifySignature(header, body)).toBe(true);
+    });
+  });
+});

--- a/src/push-subscriptions.ts
+++ b/src/push-subscriptions.ts
@@ -1,0 +1,238 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Error thrown when push subscription signature verification fails
+ */
+export class PushSubscriptionVerificationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = "PushSubscriptionVerificationError";
+  }
+}
+
+/**
+ * Parsed signature header components
+ */
+export interface SignatureComponents {
+  timestamp: number;
+  signature: string;
+}
+
+/**
+ * Headers expected from a push subscription request
+ */
+export interface PushSubscriptionHeaders {
+  "sailhouse-signature": string;
+  identifier: string;
+  "event-id": string;
+}
+
+/**
+ * Push subscription payload structure
+ */
+export interface PushSubscriptionPayload<T = any> {
+  data: T;
+  metadata?: Record<string, any>;
+  id: string;
+  timestamp: string;
+}
+
+/**
+ * Verification options
+ */
+export interface VerificationOptions {
+  /** Tolerance for timestamp validation in seconds (default: 300) */
+  tolerance?: number;
+}
+
+/**
+ * Push subscription signature verifier
+ */
+export class PushSubscriptionVerifier {
+  private readonly secret: string;
+
+  constructor(secret: string) {
+    if (!secret) {
+      throw new Error("Push subscription secret is required");
+    }
+    this.secret = secret;
+  }
+
+  /**
+   * Verify a push subscription signature
+   * @param signature The Sailhouse-Signature header value
+   * @param body The raw request body as string
+   * @param options Verification options
+   * @returns true if signature is valid
+   * @throws PushSubscriptionVerificationError if verification fails
+   */
+  verifySignature(
+    signature: string,
+    body: string,
+    options: VerificationOptions = {},
+  ): boolean {
+    const tolerance = options.tolerance ?? 300;
+
+    try {
+      // Parse signature header
+      const { timestamp, signature: headerSignature } =
+        this.parseSignatureHeader(signature);
+
+      // Validate timestamp
+      if (!this.isTimestampValid(timestamp, tolerance)) {
+        throw new PushSubscriptionVerificationError(
+          `Request timestamp is too old. Maximum age: ${tolerance} seconds`,
+          "TIMESTAMP_TOO_OLD",
+        );
+      }
+
+      // Calculate expected signature
+      const expectedSignature = this.calculateSignature(timestamp, body);
+
+      // Perform constant-time comparison
+      if (!this.constantTimeEqual(expectedSignature, headerSignature)) {
+        throw new PushSubscriptionVerificationError(
+          "Signature verification failed",
+          "INVALID_SIGNATURE",
+        );
+      }
+
+      return true;
+    } catch (error) {
+      if (error instanceof PushSubscriptionVerificationError) {
+        throw error;
+      }
+      throw new PushSubscriptionVerificationError(
+        `Signature verification failed: ${error instanceof Error ? error.message : String(error)}`,
+        "VERIFICATION_ERROR",
+      );
+    }
+  }
+
+  /**
+   * Parse the Sailhouse-Signature header
+   * @param header The signature header value
+   * @returns Parsed timestamp and signature
+   */
+  parseSignatureHeader(header: string): SignatureComponents {
+    if (!header) {
+      throw new PushSubscriptionVerificationError(
+        "Signature header is required",
+        "MISSING_SIGNATURE_HEADER",
+      );
+    }
+
+    const elements = header.split(",");
+    let timestamp: number | undefined;
+    let signature: string | undefined;
+
+    for (const element of elements) {
+      const trimmed = element.trim();
+      const [key, value] = trimmed.split("=");
+
+      if (key === "t") {
+        const parsedTimestamp = parseInt(value, 10);
+        if (isNaN(parsedTimestamp)) {
+          throw new PushSubscriptionVerificationError(
+            "Invalid timestamp in signature header",
+            "INVALID_TIMESTAMP",
+          );
+        }
+        timestamp = parsedTimestamp;
+      } else if (key === "v1") {
+        signature = value;
+      }
+    }
+
+    if (timestamp === undefined || !signature) {
+      throw new PushSubscriptionVerificationError(
+        "Invalid signature header format. Expected format: t=<timestamp>,v1=<signature>",
+        "INVALID_SIGNATURE_FORMAT",
+      );
+    }
+
+    return { timestamp, signature };
+  }
+
+  /**
+   * Check if timestamp is within tolerance
+   * @param timestamp The timestamp to validate
+   * @param tolerance Maximum age in seconds
+   * @returns true if timestamp is valid
+   */
+  isTimestampValid(timestamp: number, tolerance: number): boolean {
+    const currentTime = Math.floor(Date.now() / 1000);
+    return currentTime - timestamp <= tolerance && timestamp <= currentTime;
+  }
+
+  /**
+   * Calculate HMAC-SHA256 signature for the payload
+   * @param timestamp The timestamp from the signature header
+   * @param body The raw request body
+   * @returns Hex-encoded signature
+   */
+  calculateSignature(timestamp: number, body: string): string {
+    const payload = `${timestamp}.${body}`;
+    return createHmac("sha256", this.secret).update(payload).digest("hex");
+  }
+
+  /**
+   * Perform constant-time comparison to prevent timing attacks
+   * @param expected The expected signature
+   * @param actual The actual signature from header
+   * @returns true if signatures match
+   */
+  private constantTimeEqual(expected: string, actual: string): boolean {
+    try {
+      return timingSafeEqual(
+        Buffer.from(expected, "hex"),
+        Buffer.from(actual, "hex"),
+      );
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Convenience function for one-off signature verification
+ * @param secret The push subscription secret
+ * @param signature The Sailhouse-Signature header value
+ * @param body The raw request body as string
+ * @param options Verification options
+ * @returns true if signature is valid
+ * @throws PushSubscriptionVerificationError if verification fails
+ */
+export function verifyPushSubscriptionSignature(
+  secret: string,
+  signature: string,
+  body: string,
+  options: VerificationOptions = {},
+): boolean {
+  const verifier = new PushSubscriptionVerifier(secret);
+  return verifier.verifySignature(signature, body, options);
+}
+
+/**
+ * Safe verification that returns a boolean instead of throwing
+ * @param secret The push subscription secret
+ * @param signature The Sailhouse-Signature header value
+ * @param body The raw request body as string
+ * @param options Verification options
+ * @returns true if signature is valid, false otherwise
+ */
+export function verifyPushSubscriptionSignatureSafe(
+  secret: string,
+  signature: string,
+  body: string,
+  options: VerificationOptions = {},
+): boolean {
+  try {
+    return verifyPushSubscriptionSignature(secret, signature, body, options);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Introduces a slim helper method for push subscription HMAC verification, based on the documentation we have at https://docs.sailhouse.dev/guides/receiving-push-events

This will also publish 1.5.0